### PR TITLE
Allow multiple simultaneous clients

### DIFF
--- a/lib/plaid.rb
+++ b/lib/plaid.rb
@@ -7,6 +7,7 @@ require 'plaid/user'
 require 'plaid/transaction'
 require 'plaid/info'
 require 'plaid/income'
+require 'plaid/client'
 
 require 'uri'
 
@@ -16,15 +17,8 @@ module Plaid
   PRODUCTS = %i(connect auth info income risk).freeze
 
   class <<self
-    # Public: The String Plaid account client ID to authenticate requests.
-    attr_accessor :client_id
-
-    # Public: The String Plaid account secret to authenticate requests.
-    attr_accessor :secret
-
-    # Public: Plaid environment to use. Should be set to :tartan, :api, or a
-    # full URL like 'https://tartan.plaid.com'.
-    attr_accessor :env
+    # Public: The default Client.
+    attr_accessor :client
 
     # Public: The Integer read timeout for requests to Plaid HTTP API.
     # Should be specified in seconds. Default value is 120 (2 minutes).
@@ -45,24 +39,9 @@ module Plaid
     #
     # Returns nothing.
     def config
-      yield self
-
-      case env
-      when :tartan, :api
-        self.env = "https://#{env}.plaid.com/"
-      when String
-        begin
-          URI.parse(env)
-        rescue
-          raise ArgumentError, "Invalid URL in Plaid.env (#{env.inspect}). " \
-                               'Specify either Symbol (:tartan, :api), or a ' \
-                               "full URL, like 'https://tartan.plaid.com'"
-        end
-      else
-        raise ArgumentError, "Invalid value for Plaid.env (#{env.inspect}): " \
-                             'must be :tartan, :api, or a full URL, ' \
-                             "e.g. 'https://tartan.plaid.com'"
-      end
+      client = Client.new
+      yield client
+      self.client = client
     end
 
     # Internal: Symbolize keys (and values) for a hash.

--- a/lib/plaid/category.rb
+++ b/lib/plaid/category.rb
@@ -35,9 +35,12 @@ module Plaid
     #
     # Does a GET /categories call.
     #
+    # client - The Plaid::Client instance used to connect
+    #          (default: Plaid.client).
+    #
     # Returns an Array of Category instances.
-    def self.all
-      Connector.new(:categories).get.map do |category_data|
+    def self.all(client: nil)
+      Connector.new(:categories, client: client).get.map do |category_data|
         new(category_data)
       end
     end
@@ -46,12 +49,14 @@ module Plaid
     #
     # Does a GET /categories/:id call.
     #
-    # id - the String category ID (e.g. "17001013").
+    # id     - the String category ID (e.g. "17001013").
+    # client - The Plaid::Client instance used to connect
+    #          (default: Plaid.client).
     #
     # Returns a Category instance or raises Plaid::NotFoundError if category
     # with given id is not found.
-    def self.get(id)
-      new Connector.new(:categories, id).get
+    def self.get(id, client: nil)
+      new Connector.new(:categories, id, client: client).get
     end
   end
 end

--- a/lib/plaid/client.rb
+++ b/lib/plaid/client.rb
@@ -1,0 +1,67 @@
+module Plaid
+  # Public: A class encapsulating client_id, secret, and Plaid API URL.
+  class Client
+    # Public: The String Plaid account client ID to authenticate requests.
+    attr_accessor :client_id
+
+    # Public: The String Plaid account secret to authenticate requests.
+    attr_accessor :secret
+
+    # Public: Plaid environment, i.e. String base URL of the API site.
+    #
+    # E.g. 'https://tartan.plaid.com'.
+    attr_reader :env
+
+    # Public: Set Plaid environment to use.
+    #
+    # env - The Symbol (:tartan, :api), or a full String URL like
+    #       'https://tartan.plaid.com'.
+    def env=(env)
+      case env
+      when :tartan, :api
+        @env = "https://#{env}.plaid.com/"
+      when String
+        begin
+          URI.parse(env)
+          @env = env
+        rescue
+          raise ArgumentError, 'Invalid URL in Plaid::Client.env' \
+                               " (#{env.inspect}). " \
+                               'Specify either Symbol (:tartan, :api), or a ' \
+                               "full URL, like 'https://tartan.plaid.com'"
+        end
+      else
+        raise ArgumentError, 'Invalid value for Plaid::Client.env' \
+                             " (#{env.inspect}): " \
+                             'must be :tartan, :api, or a full URL, ' \
+                             "e.g. 'https://tartan.plaid.com'"
+      end
+    end
+
+    # Public: Construct a Client instance.
+    #
+    # env       - The Symbol (:tartan, :api), or a full String URL like
+    #             'https://tartan.plaid.com'.
+    # client_id - The String Plaid account client ID to authenticate requests.
+    # secret    - The String Plaid account secret to authenticate requests.
+    def initialize(env: nil, client_id: nil, secret: nil)
+      env && self.env = env
+      self.client_id = client_id
+      self.secret = secret
+    end
+
+    # Public: Check if client_id is configured.
+    #
+    # Returns true if it is.
+    def client_id_configured?
+      @client_id.is_a?(String) && !@client_id.empty?
+    end
+
+    # Public: Check if client_id is configured.
+    #
+    # Returns true if it is.
+    def secret_configured?
+      @secret.is_a?(String) && !@secret.empty?
+    end
+  end
+end

--- a/lib/plaid/institution.rb
+++ b/lib/plaid/institution.rb
@@ -62,9 +62,12 @@ module Plaid
     #
     # Does a GET /institutions call.
     #
+    # client - The Plaid::Client instance used to connect
+    #          (default: Plaid.client).
+    #
     # Returns an Array of Institution instances.
-    def self.all
-      Connector.new(:institutions).get.map do |idata|
+    def self.all(client: nil)
+      Connector.new(:institutions, client: client).get.map do |idata|
         new(idata)
       end
     end
@@ -73,12 +76,14 @@ module Plaid
     #
     # Does a GET /institutions/:id call.
     #
-    # id - the String institution ID (e.g. "5301a93ac140de84910000e0").
+    # id     - the String institution ID (e.g. "5301a93ac140de84910000e0").
+    # client - The Plaid::Client instance used to connect
+    #          (default: Plaid.client).
     #
     # Returns an Institution instance or raises Plaid::NotFoundError if
     # institution with given id is not found.
-    def self.get(id)
-      new Connector.new(:institutions, id).get
+    def self.get(id, client: nil)
+      new Connector.new(:institutions, id, client: client).get
     end
 
     # Public: Get information about the "long tail" institutions supported

--- a/test/test_category.rb
+++ b/test/test_category.rb
@@ -34,6 +34,15 @@ class PlaidCategoryTest < MiniTest::Test
     assert_equal ['Travel', 'Lodging', 'Hotels and Motels'], cat.hierarchy
   end
 
+  def test_all_categories_with_custom_client
+    client = Plaid::Client.new(env: 'https://example.com')
+
+    stub_request(:get, 'https://example.com/categories')
+      .to_return(status: 200, body: fixture(:categories))
+
+    Plaid::Category.all(client: client)
+  end
+
   def test_get_single_category
     stub_request(:get, 'https://tartan.plaid.com/categories/19012002')
       .to_return(status: 200, body: fixture('category_19012002'))
@@ -45,6 +54,15 @@ class PlaidCategoryTest < MiniTest::Test
     assert_equal :place, cat.type
     assert_equal ['Shops', 'Clothing and Accessories', 'Swimwear'],
                  cat.hierarchy
+  end
+
+  def test_get_single_category_with_custom_client
+    client = Plaid::Client.new(env: 'https://example.com')
+
+    stub_request(:get, 'https://example.com/categories/19012002')
+      .to_return(status: 200, body: fixture('category_19012002'))
+
+    Plaid::Category.get '19012002', client: client
   end
 
   def test_get_nonexistent_category

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+# Internal: The test for Plaid::Client
+class PlaidClientTest < MiniTest::Test
+  def test_symbol_environments
+    client = Plaid::Client.new
+    client.env = :tartan
+
+    assert_equal 'https://tartan.plaid.com/', client.env
+
+    client2 = Plaid::Client.new
+    client2.env = :api
+
+    assert_equal 'https://api.plaid.com/', client2.env
+  end
+
+  def test_string_url
+    client = Plaid::Client.new
+    client.env = 'https://www.example.com/'
+
+    assert_equal 'https://www.example.com/', client.env
+  end
+
+  def test_wrong_values_for_env
+    assert_raises ArgumentError do
+      Plaid::Client.new(env: 123)
+    end
+
+    assert_raises ArgumentError do
+      Plaid.config do |p|
+        Plaid::Client.new(env: :unknown)
+      end
+    end
+  end
+end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -7,13 +7,13 @@ class PlaidConfigTest < MiniTest::Test
       p.env = :tartan
     end
 
-    assert_equal 'https://tartan.plaid.com/', Plaid.env
+    assert_equal 'https://tartan.plaid.com/', Plaid.client.env
 
     Plaid.config do |p|
       p.env = :api
     end
 
-    assert_equal 'https://api.plaid.com/', Plaid.env
+    assert_equal 'https://api.plaid.com/', Plaid.client.env
   end
 
   def test_string_url
@@ -21,7 +21,7 @@ class PlaidConfigTest < MiniTest::Test
       p.env = 'https://www.example.com/'
     end
 
-    assert_equal 'https://www.example.com/', Plaid.env
+    assert_equal 'https://www.example.com/', Plaid.client.env
   end
 
   def test_wrong_values_for_env

--- a/test/test_connector.rb
+++ b/test/test_connector.rb
@@ -20,26 +20,26 @@ class PlaidConnectorTest < MiniTest::Test
     reset_config
     tartan
 
-    Plaid.secret = 'fun'
+    Plaid.client.secret = 'fun'
 
     e = assert_raises(Plaid::NotConfiguredError) do
       Plaid::Connector.new(:connect, auth: true)
     end
 
-    assert_match(/must set Plaid\.client_id/, e.message)
+    assert_match(/must set Plaid::Client\.client_id/, e.message)
   end
 
   def test_secret_not_set
     reset_config
     tartan
 
-    Plaid.client_id = 'fun'
+    Plaid.client.client_id = 'fun'
 
     e = assert_raises(Plaid::NotConfiguredError) do
       Plaid::Connector.new(:connect, auth: true)
     end
 
-    assert_match(/must set Plaid\.secret/, e.message)
+    assert_match(/must set Plaid::Client\.secret/, e.message)
   end
 
   def test_200

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,9 +10,8 @@ module TestHelpers
   end
 
   def reset_config
-    Plaid.client_id = nil
-    Plaid.secret = nil
-    Plaid.env = nil
+    Plaid.config do |_|
+    end
   end
 
   def tartan

--- a/test/test_institution.rb
+++ b/test/test_institution.rb
@@ -39,6 +39,15 @@ class PlaidInstitutionTest < MiniTest::Test
     assert_equal 'chase', i.type
   end
 
+  def test_all_institutions_with_custom_client
+    client = Plaid::Client.new(env: 'https://example.com')
+
+    stub_request(:get, 'https://example.com/institutions')
+      .to_return(status: 200, body: fixture(:institutions))
+
+    Plaid::Institution.all client: client
+  end
+
   def test_get_single_institution
     stub_request(:get, 'https://tartan.plaid.com/institutions/5301a99504977c52b60000d0')
       .to_return(status: 200, body: fixture('institution_chase'))
@@ -55,6 +64,15 @@ class PlaidInstitutionTest < MiniTest::Test
     assert_equal 'Chase', i.name
     assert_equal %i(connect auth balance info income risk), i.products
     assert_equal 'chase', i.type
+  end
+
+  def test_get_single_institution_with_custom_client
+    client = Plaid::Client.new(env: 'https://example.com')
+
+    stub_request(:get, 'https://example.com/institutions/123')
+      .to_return(status: 200, body: fixture('institution_chase'))
+
+    Plaid::Institution.get '123', client: client
   end
 
   def test_get_nonexistent_institution


### PR DESCRIPTION
Extract (env, client_id, secret) triad into a separate class, `Plaid::Client`, and allow to specify a custom client as an option to all needed methods. There's still `Plaid.client` for cases when the custom client wasn't specified.
