### PR TITLE
MFA 

### DIFF
--- a/lib/plaid.rb
+++ b/lib/plaid.rb
@@ -74,6 +74,7 @@ module Plaid
     # Returns a Hash with keys.to_sym (or nil if hash is nil).
     def symbolize_hash(hash, values: false)
       return unless hash
+      return hash.map { |h| symbolize_hash(h) } if hash.is_a?(Array)
 
       hash.each_with_object({}) do |(k, v), memo|
         memo[k.to_sym] = values ? v.to_sym : v

--- a/test/fixtures/mfa_code_sent.json
+++ b/test/fixtures/mfa_code_sent.json
@@ -1,0 +1,7 @@
+{
+  "type": "device",
+  "mfa": {
+    "message": "Code sent to xxx-xxx-5309"
+  },
+  "access_token": "t0k3n"
+}

--- a/test/fixtures/mfa_list.json
+++ b/test/fixtures/mfa_list.json
@@ -1,0 +1,9 @@
+{
+  "type": "list",
+  "mfa": [
+    {"mask":"t..t@plaid.com", "type":"email"},
+    {"mask":"xxx-xxx-5309", "type":"phone"},
+    {"mask":"SafePass Card", "type":"card"}
+  ],
+  "access_token": "t0k3n"
+}

--- a/test/fixtures/mfa_questions.json
+++ b/test/fixtures/mfa_questions.json
@@ -1,0 +1,5 @@
+{
+  "type": "questions",
+  "mfa": [{"question":"What was the name of your first pet?"}],
+  "access_token": "t0k3n"
+}


### PR DESCRIPTION
An implementation of MFA for all Plaid products' API. Following methods are added:
- `User#mfa?`
- `User#mfa`
- `User#mfa_type`
- `User#mfa_step`
